### PR TITLE
Fixed bit corruption in viterbi decoder

### DIFF
--- a/decode/viterbi.c
+++ b/decode/viterbi.c
@@ -162,7 +162,7 @@ uint32_t viterbi_chainback(uint8_t* out, size_t pos, uint16_t len)
     uint8_t state = 0;
     size_t bitPos = len+4;
 
-    memset(out, 0, (len-1)/8+1);
+    memset(out, 0, (bitPos/8)+1);
 
     while(pos > 0)
     {


### PR DESCRIPTION
This small but important PR fixes an incorrect length in a memset inside the viterbi decoder. The code writes up to an index of bitPos/8 but the memset length is not computed the same way. This results in the few last bits from the output of the viterbi decoder to not be set to 0 properly and thus they are sometimes corrupted.

This but may not appear of the code calling the viterbi_decode_punctured takes care of setting the output buffer to 0.

IMO this memset does not belong here and it is the code calling the viterbi_decode_punctured that should take care of resetting the buffer provided as output buffer.